### PR TITLE
docs: add the diff standard

### DIFF
--- a/standard.md
+++ b/standard.md
@@ -46,7 +46,7 @@ The schema has the following <u>fixed</u> fields:
        - `externalDocs`
        - `bindings`
        - `traits`
-       - `message`
+       - [`message`](#message)
          - `headers`
            - `$ref`
            - [SchemaObject](https://www.asyncapi.com/docs/specifications/v2.0.0#schemaObject)
@@ -66,8 +66,6 @@ The schema has the following <u>fixed</u> fields:
          - `traits`
          - `description`
          - `payload`
-           - `type`
-           - `properties`
      - `publish`
      - `parameters`
        - patterned-field
@@ -79,7 +77,7 @@ The schema has the following <u>fixed</u> fields:
 1. [`tags`](#tags)
 1. [`externalDocs`](#externaldocs)
 
-**NOTE:** At the moment, bindings are out of scope for this library as these are yet not mature enough and lack proper tooling support.Thus, we have considered it as **non-breaking** change for the time being.
+**NOTE:** At the moment, bindings are out of scope for this library as these are yet not mature enough and lack proper tooling support. Thus, we have considered it as **non-breaking** change for the time being.
 
 ## The Standard
 
@@ -141,12 +139,13 @@ Change in `defaultContentType` is **Breaking**
 
 **Breaking:**
 
-1.  Removal of channel
-1.  Removal of `subscribe` or `publish` field
-1.  Change in value of `$ref`
+1. Removal of channel(same as changing the channel name)
+1. Removal of `subscribe` or `publish` field
 
 **Non-Breaking:**
 
+1. Change in value of `$ref`
+     -  During the parsing phase, the `$ref`s will get inlined. So, the change will only depend on the inlined data.
 1. Addition of a channel
 1. Change in `description`
 1. Addition of `subscribe` or `publish` field
@@ -170,20 +169,21 @@ Change in `defaultContentType` is **Breaking**
 **Breaking:**
 
 1. Change in `contentType`
-1. Change in `name`
 1. Change in `payload`
 1. Change in `traits`
 1. Change in `headers`
+1. Change in `location` inside `correlationId`
 
 **Non-Breaking:**
 
+1. Change in `name`
 1. Change in `summary`
 1. Change in `description`
 1. Change in `examples`
 1. Change in `title`
 1. Change in `tags`
 1. Change in `externalDocs`
-1. Change in `correlationId`
+1. Change `description` in `correlationId`
 
 #### `parameters`
 
@@ -191,10 +191,10 @@ Change in `defaultContentType` is **Breaking**
 
 1. Change in `schema`
 1. Change in `location`
-1. Change in value of `$ref`
 
 **Non-Breaking:**
 
+1. Change in value of `$ref`
 1. Change in `description`
 
 ### `components`
@@ -227,19 +227,17 @@ Any change in `externalDocs` is **non-breaking**.
 1. Change in `default` (`variables`) in `servers`
 1. Removal in `enum` (`variables`) in `servers`
 1. Change in `security` in `servers`
-1.  Removal of channel
-1.  Removal of `subscribe` or `publish` field in `channels`
-1.  Change in value of `$ref` in `channels`
+1. Removal of channel(same as changing the channel name)
+1. Removal of `subscribe` or `publish` field in `channels`
 1. Change in `operationId` in `subscribe`|`publish`
 1. Change in `traits` in `subscribe`|`publish`
 1. Change in `contentType` in `message`
-1. Change in `name` in `message`
 1. Change in `payload` in `message`
 1. Change in `traits` in `message`
 1. Change in `headers` in `message`
+1. Change in `location` inside `correlationId` in `message`
 1. Change in `schema` in `parameters`
 1. Change in `location` in `parameters`
-1. Change in value of `$ref` in `parameters`
 
 ### Non-Breaking changes
 
@@ -253,20 +251,23 @@ Any change in `externalDocs` is **non-breaking**.
 1. Change in `description` (`variables`) in `servers`
 1. Change in `examples` (`variables`) in `servers`
 1. Addition in `enum` (`variables`) in `servers`
+1. Change in value of `$ref` in `channels`
 1. Change in `description` in `channels`
 1. Addition of `subscribe` or `publish` field in `channels`
 1. Change in `summary` in `subscribe`|`publish`
 1. Change in `description` in `subscribe`|`publish`
 1. Change in `externalDocs` in `subscribe`|`publish`
 1. Change in `tags` in `subscribe`|`publish`
+1. Change in `name` in `message`
 1. Change in `summary` in `message`
 1. Change in `description` in `message`
 1. Change in `examples` in `message`
 1. Change in `title` in `message`
 1. Change in `tags` in `message`
 1. Change in `externalDocs` in `message`
-1. Change in `correlationId` in `message`
+1. Change in `description` inside `correlationId` in `message`
 1. Change in `description` in `parameters`
 1. Change in `components`
 1. Change in `tags`
 1. Change in `externalDocs`
+1. Change in value of `$ref` in `parameters`

--- a/standard.md
+++ b/standard.md
@@ -1,0 +1,204 @@
+# AsyncAPI Diff Standard
+
+## The schema
+
+The schema has the following <u>fixed</u> fields:
+
+1. [`asyncapi`](#asyncapi)
+1. [`id`](#id)
+1. [`info`](#info)
+   - `title`
+   - `version`
+   - `description`
+   - `termsOfService`
+   - `contact`
+     - `name`
+     - `url`
+     - `email`
+   - `license`
+     - `name`
+     - `url`
+1. [`servers`](#servers)
+   - patterned-field (name)
+     - `url`
+     - `description`
+     - `protocol`
+     - `protocolVersion`
+     - `variables`
+       - field
+         - `enum`
+         - `default`
+         - `description`
+         - `examples`
+     - `security`
+     - `bindings`
+1. [`channels`](#channels)
+   - patterned-field
+     - `$ref`
+     - `description`
+     - `bindings`
+     - `subscribe`
+       - `operationId`
+       - `summary`
+       - `description`
+       - `tags`
+       - `externalDocs`
+       - `bindings`
+       - `traits`
+       - `message`
+         - `headers`
+           - `$ref`
+           - [SchemaObject](https://www.asyncapi.com/docs/specifications/v2.0.0#schemaObject)
+         - `correlationId`
+           - `$ref`
+           - `description`
+           - `location`
+         - `schemaFormat`
+         - `contentType`
+         - `name`
+         - `title`
+         - `summary`
+         - `tags`
+         - `externalDocs`
+         - `bindings`
+         - `examples`
+         - `traits`
+         - `description`
+         - `payload`
+           - `type`
+           - `properties`
+     - `publish`
+     - `parameters`
+       - patterned-field
+         - `$ref`
+         - `description`
+         - `schema`
+         - `location`
+1. [`components`](#components)
+1. [`tags`](#tags)
+1. [`externalDocs`](#externaldocs)
+
+## The Standard
+
+### `asyncapi`
+
+ex. Version: `major`.`minor`.`patch`
+
+**Breaking:**
+
+1. Change in `major` version
+
+**Non-Breaking:**
+
+1. Change in `minor`/`patch` version
+
+### `id`
+
+Any change in `id` is **Non-Breaking**
+
+### `info`
+
+**Breaking:**
+
+1. Change in `version`
+1. Change in `termsOfService`
+1. Change in `license` field
+
+**Non-Breaking:**
+
+1. Change in `title`
+1. Change in `description`
+1. Change in `contact` field
+
+### `servers`
+
+**Breaking:**
+
+1. Removal of a server(equivalent to change in server name)
+1. Change in `url`
+1. Change in `protocol`
+1. Change in `protocolVersion`
+1. Change in `default` (`variables`)
+1. Removal in `enum` (`variables`)
+1. Change in `security`
+
+**Non-Breaking:**
+
+1. Server being added
+1. Change in `description`
+1. Change in `description` (`variables`)
+1. Change in `examples` (`variables`)
+1. Addition in `enum` (`variables`)
+
+### `channels`
+
+**Breaking:**
+
+1.  Removal of channel
+1.  Removal of `subscribe` or `publish` field
+1.  Change in value of `$ref`
+
+**Non-Breaking:**
+
+1. Change in `description`
+1. Addition of `subscribe` or `publish` field
+
+#### `subscribe` | `publish`
+
+**Breaking:**
+
+1. Change in `operationId`
+1. Change in `traits`
+
+**Non-Breaking:**
+
+1. Change in `summary`
+1. Change in `description`
+1. Change in `externalDocs`
+1. Change in `tags`
+
+##### `message`
+
+**Breaking:**
+
+1. Change in `contentType`
+2. Change in `name`
+3. Change in `payload`
+4. Change in `traits`
+5. Change in `headers`
+
+**Non-Breaking:**
+
+1. Change in `summary`
+1. Change in `description`
+1. Change in `examples`
+1. Change in `title`
+1. Change in `tags`
+1. Change in `externalDocs`
+1. Change in `correlationId`
+
+#### `parameters`
+
+**Breaking:**
+
+1. Change in `schema`
+1. Change in `location`
+1. Change in value of `$ref`
+
+**Non-Breaking:**
+
+1. Change in `description`
+
+### `components`
+
+Any change in `components` is **non-breaking**.
+
+**Reason:** The parser will inline the `$ref` during the parsing phase.
+
+### `tags`
+
+Any change in `tags` is **non-breaking**.
+
+### `externalDocs`
+
+Any change in `externalDocs` is **non-breaking**.

--- a/standard.md
+++ b/standard.md
@@ -1,5 +1,19 @@
 # AsyncAPI Diff Standard
 
+## Types
+
+The changes has been classified into **three** types:
+
+1. `breaking` - The change is a breaking change.
+1. `non-breaking` - The change is a non-breaking change.
+1. `unclassified` - The change is unclassified. User need to handle this themselves.
+
+## Notes
+
+1. At the moment, bindings are out of scope for this library as these are yet not mature enough and lack proper tooling support. Thus, we have considered it as **unclassified** change for the time being.
+
+1. Some properties which are marked as `non-breaking` or `unclassified` changes does not have any classification for their nested children properties. Therefore, it is assumend that these children properties will be `non-breaking` or `unclassified` as well.
+
 ## The schema
 
 The schema has the following <u>fixed</u> fields:
@@ -26,7 +40,7 @@ The schema has the following <u>fixed</u> fields:
      - `protocol`
      - `protocolVersion`
      - `variables`
-       - field
+       - patterened-field
          - `enum`
          - `default`
          - `description`
@@ -46,6 +60,14 @@ The schema has the following <u>fixed</u> fields:
        - `externalDocs`
        - `bindings`
        - `traits`
+         - `operationId` (string)
+         - `summary` (string)
+         - `description` (string)
+         - `tags`
+           - `name`
+           - `description`
+         - `externalDocs`
+         - `bindings`
        - [`message`](#message)
          - `headers`
            - `$ref`
@@ -64,6 +86,18 @@ The schema has the following <u>fixed</u> fields:
          - `bindings`
          - `examples`
          - `traits`
+           - `headers`
+           - `correlationId`
+           - `schemaFormat`
+           - `contentType`
+           - `name`
+           - `title`
+           - `summary`
+           - `description`
+           - `tags`
+           - `externalDocs`
+           - `bindings`
+           - `examples`
          - `description`
          - `payload`
      - `publish`
@@ -76,8 +110,8 @@ The schema has the following <u>fixed</u> fields:
 1. [`components`](#components)
 1. [`tags`](#tags)
 1. [`externalDocs`](#externaldocs)
-
-**NOTE:** At the moment, bindings are out of scope for this library as these are yet not mature enough and lack proper tooling support. Thus, we have considered it as **non-breaking** change for the time being.
+   - `description`
+   - `url`
 
 ## The Standard
 
@@ -107,7 +141,7 @@ Change in `defaultContentType` is **Breaking**
 
 1. Change in `version`
 1. Change in `termsOfService`
-1. Change in `license` field
+1. Change in `license` field(including `name` and `url`)
 
 **Non-Breaking:**
 
@@ -135,17 +169,22 @@ Change in `defaultContentType` is **Breaking**
 1. Change in `examples` (`variables`)
 1. Addition in `enum` (`variables`)
 
+**Unclassified**
+
+1. Change in `bindings`
+
 ### `channels`
 
 **Breaking:**
 
 1. Removal of channel(same as changing the channel name)
 1. Removal of `subscribe` or `publish` field
+1. Change of `parameters` field
 
 **Non-Breaking:**
 
 1. Change in value of `$ref`
-     -  During the parsing phase, the `$ref`s will get inlined. So, the change will only depend on the inlined data.
+   - During the parsing phase, the `$ref`s will get inlined. So, the change will only depend on the inlined data.
 1. Addition of a channel
 1. Change in `description`
 1. Addition of `subscribe` or `publish` field
@@ -155,7 +194,7 @@ Change in `defaultContentType` is **Breaking**
 **Breaking:**
 
 1. Change in `operationId`
-1. Change in `traits`
+1. Change in `operationdId`(`traits`)
 
 **Non-Breaking:**
 
@@ -163,16 +202,24 @@ Change in `defaultContentType` is **Breaking**
 1. Change in `description`
 1. Change in `externalDocs`
 1. Change in `tags`
+1. Change in `summary`(`traits`)
+1. Change in `description`(`traits`)
+1. Change in `externalDocs`(`traits`)
+1. Change in `tags`(`traits`)
+
+**Unclassified:**
+
+1. Change in `bindings`
 
 ##### `message`
 
 **Breaking:**
 
+1. Change in `schemaFormat`
 1. Change in `contentType`
 1. Change in `payload`
-1. Change in `traits`
-1. Change in `headers`
-1. Change in `location` inside `correlationId`
+1. Change in `schemaFromat`, `location` in `correlationId` (`traits`)
+1. Change in `location` in `correlationId`
 
 **Non-Breaking:**
 
@@ -184,18 +231,30 @@ Change in `defaultContentType` is **Breaking**
 1. Change in `tags`
 1. Change in `externalDocs`
 1. Change `description` in `correlationId`
+1. Change in `name`, `title`, `summary`, `description`, `tags`, `externalDocs`, `examples` (`traits`)
+
+**Unclassified:**
+
+1. Change in `headers`
+1. Change in `bindings`
+1. Change in `headers` (`traits`)
+1. Change in `bindigs` (`traits`)
 
 #### `parameters`
 
 **Breaking:**
 
-1. Change in `schema`
 1. Change in `location`
 
 **Non-Breaking:**
 
 1. Change in value of `$ref`
 1. Change in `description`
+
+**Unclassified:**
+
+1. Change in `schema`
+   - A JSON schema.
 
 ### `components`
 
@@ -219,7 +278,7 @@ Any change in `externalDocs` is **non-breaking**.
 1. Change in `defaultContentType` field
 1. Change in `version` in `info`
 1. Change in `termsOfService` in `info`
-1. Change in `license` field in `info`
+1. Change in `license` field in `info`(including `name` and `url`)
 1. Removal of a server(equivalent to change in server name)
 1. Change in `url` in `servers`
 1. Change in `protocol` in `servers`
@@ -229,8 +288,11 @@ Any change in `externalDocs` is **non-breaking**.
 1. Change in `security` in `servers`
 1. Removal of channel(same as changing the channel name)
 1. Removal of `subscribe` or `publish` field in `channels`
+1. Change in `parameters` field in `channels`
 1. Change in `operationId` in `subscribe`|`publish`
+1. Change in `operationId`(`traits`) in `subscribe`|`publish`
 1. Change in `traits` in `subscribe`|`publish`
+1. Change in `schemaFormat` in `message`
 1. Change in `contentType` in `message`
 1. Change in `payload` in `message`
 1. Change in `traits` in `message`
@@ -267,7 +329,14 @@ Any change in `externalDocs` is **non-breaking**.
 1. Change in `externalDocs` in `message`
 1. Change in `description` inside `correlationId` in `message`
 1. Change in `description` in `parameters`
+1. Change in value of `$ref` in `parameters`
 1. Change in `components`
 1. Change in `tags`
 1. Change in `externalDocs`
-1. Change in value of `$ref` in `parameters`
+
+### Unclassified changes
+
+1. All change in `bindings`
+1. Change in `headers` in `message`
+1. Change in `headers` in message `traits`
+1. Change in `schema`in `parameters`

--- a/standard.md
+++ b/standard.md
@@ -217,7 +217,6 @@ Change in `defaultContentType` is **Breaking**
 
 1. Change in `schemaFormat`
 1. Change in `contentType`
-1. Change in `payload`
 1. Change in `schemaFromat`, `location` in `correlationId` (`traits`)
 1. Change in `location` in `correlationId`
 
@@ -239,6 +238,7 @@ Change in `defaultContentType` is **Breaking**
 1. Change in `bindings`
 1. Change in `headers` (`traits`)
 1. Change in `bindigs` (`traits`)
+1. Change in `payload`
 
 #### `parameters`
 
@@ -294,7 +294,6 @@ Any change in `externalDocs` is **non-breaking**.
 1. Change in `traits` in `subscribe`|`publish`
 1. Change in `schemaFormat` in `message`
 1. Change in `contentType` in `message`
-1. Change in `payload` in `message`
 1. Change in `traits` in `message`
 1. Change in `headers` in `message`
 1. Change in `location` inside `correlationId` in `message`
@@ -340,3 +339,4 @@ Any change in `externalDocs` is **non-breaking**.
 1. Change in `headers` in `message`
 1. Change in `headers` in message `traits`
 1. Change in `schema`in `parameters`
+1. Change in `payload` in `message`

--- a/standard.md
+++ b/standard.md
@@ -79,6 +79,8 @@ The schema has the following <u>fixed</u> fields:
 1. [`tags`](#tags)
 1. [`externalDocs`](#externaldocs)
 
+**NOTE:** At the moment, bindings are out of scope for this library as these are yet not mature enough and lack proper tooling support.Thus, we have considered it as **non-breaking** change for the time being.
+
 ## The Standard
 
 ### `asyncapi`
@@ -145,6 +147,7 @@ Change in `defaultContentType` is **Breaking**
 
 **Non-Breaking:**
 
+1. Addition of a channel
 1. Change in `description`
 1. Addition of `subscribe` or `publish` field
 
@@ -167,10 +170,10 @@ Change in `defaultContentType` is **Breaking**
 **Breaking:**
 
 1. Change in `contentType`
-2. Change in `name`
-3. Change in `payload`
-4. Change in `traits`
-5. Change in `headers`
+1. Change in `name`
+1. Change in `payload`
+1. Change in `traits`
+1. Change in `headers`
 
 **Non-Breaking:**
 
@@ -207,3 +210,63 @@ Any change in `tags` is **non-breaking**.
 ### `externalDocs`
 
 Any change in `externalDocs` is **non-breaking**.
+
+## Summary
+
+### Breaking changes
+
+1. Change in `major` version in `asycnapi`
+1. Change in `defaultContentType` field
+1. Change in `version` in `info`
+1. Change in `termsOfService` in `info`
+1. Change in `license` field in `info`
+1. Removal of a server(equivalent to change in server name)
+1. Change in `url` in `servers`
+1. Change in `protocol` in `servers`
+1. Change in `protocolVersion` in `servers`
+1. Change in `default` (`variables`) in `servers`
+1. Removal in `enum` (`variables`) in `servers`
+1. Change in `security` in `servers`
+1.  Removal of channel
+1.  Removal of `subscribe` or `publish` field in `channels`
+1.  Change in value of `$ref` in `channels`
+1. Change in `operationId` in `subscribe`|`publish`
+1. Change in `traits` in `subscribe`|`publish`
+1. Change in `contentType` in `message`
+1. Change in `name` in `message`
+1. Change in `payload` in `message`
+1. Change in `traits` in `message`
+1. Change in `headers` in `message`
+1. Change in `schema` in `parameters`
+1. Change in `location` in `parameters`
+1. Change in value of `$ref` in `parameters`
+
+### Non-Breaking changes
+
+1. Change in `minor`/`patch` version in `asyncapi`
+1. Change in `id` field
+1. Change in `title` in `info`
+1. Change in `description` in `info`
+1. Change in `contact` in `info`
+1. Server being added
+1. Change in `description` in `servers`
+1. Change in `description` (`variables`) in `servers`
+1. Change in `examples` (`variables`) in `servers`
+1. Addition in `enum` (`variables`) in `servers`
+1. Change in `description` in `channels`
+1. Addition of `subscribe` or `publish` field in `channels`
+1. Change in `summary` in `subscribe`|`publish`
+1. Change in `description` in `subscribe`|`publish`
+1. Change in `externalDocs` in `subscribe`|`publish`
+1. Change in `tags` in `subscribe`|`publish`
+1. Change in `summary` in `message`
+1. Change in `description` in `message`
+1. Change in `examples` in `message`
+1. Change in `title` in `message`
+1. Change in `tags` in `message`
+1. Change in `externalDocs` in `message`
+1. Change in `correlationId` in `message`
+1. Change in `description` in `parameters`
+1. Change in `components`
+1. Change in `tags`
+1. Change in `externalDocs`

--- a/standard.md
+++ b/standard.md
@@ -6,6 +6,7 @@ The schema has the following <u>fixed</u> fields:
 
 1. [`asyncapi`](#asyncapi)
 1. [`id`](#id)
+1. [`defaultContentType`](#defaultcontenttype)
 1. [`info`](#info)
    - `title`
    - `version`
@@ -32,7 +33,7 @@ The schema has the following <u>fixed</u> fields:
          - `examples`
      - `security`
      - `bindings`
-1. [`channels`](#channels)
+1. [`channels`](#channels) (aka Operations)
    - patterned-field
      - `$ref`
      - `description`
@@ -95,6 +96,10 @@ ex. Version: `major`.`minor`.`patch`
 ### `id`
 
 Any change in `id` is **Non-Breaking**
+
+### `defaultContentType`
+
+Change in `defaultContentType` is **Breaking**
 
 ### `info`
 


### PR DESCRIPTION
In order to categorize a certain change to AsyncAPI document as "breaking" or "non-breaking", we need to have a "standard" which documents what changes can be considered "breaking" or "non-breaking".

When the community agrees on this "standard", it will be mapped to a `JSON` file which will contain all the information in here, which the diff library can utilize to categorize changes.

Please note that the standard has been written from the Point of View of a Consumer(client/server), thus some changes were considered as "non-breaking" because the consumer won't be affected by that change.