### PR TITLE
refactor: remove duplicate import from `./types`

### DIFF
--- a/src/asyncapidiff.ts
+++ b/src/asyncapidiff.ts
@@ -4,10 +4,10 @@ import {
   JSONOutput,
   Changes,
   AsyncAPIDiffOptions,
+  MarkdownSubtype,
 } from './types';
 import { breaking, nonBreaking, unclassified } from './constants';
 import toProperFormat from './helpers/output/toProperFormat';
-import {MarkdownSubtype} from './types';
 
 /**
  * Implements methods to deal with diff output.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- This PR removes duplicate import for `MarkdownSubtype` from the same file. 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
Fixes https://github.com/asyncapi/diff/issues/118