### PR TITLE
chore: add asyncapi tool info file

### DIFF
--- a/.asyncapi-tool
+++ b/.asyncapi-tool
@@ -1,0 +1,9 @@
+title: AsyncAPI Diff
+filters:
+    languages:
+        - TypeScript
+    technology:
+        - TypeScript
+    categories:
+        - compare-tool
+    hasCommercial: false


### PR DESCRIPTION
Adding file based on https://github.com/asyncapi/website/issues/383

tl;dr the idea is that tools list on website will soon work basing not only on manual process, where people manually add their tools to list, but also automated process where people instead of opening a PR to website, will be able to just add a config file to their public repo.

`description` is intentionally not provided. I think it is redundant and in the website we need to make sure to not make it mandatory and fallback to GitHub repo description 